### PR TITLE
Update README.md

### DIFF
--- a/module2/README.md
+++ b/module2/README.md
@@ -242,7 +242,7 @@ While we’ll cover security and keeping up-to-date with new open source release
 
 **Money**
 
-In the Open Source Introduction course, we briefly covered that open source may be ‘free’ from a licensing cost, but by no means does that mean that it doesn’t have other costs associated with it.
+In the Open Source Introduction module, we briefly covered that open source may be ‘free’ from a licensing cost, but by no means does that mean that it doesn’t have other costs associated with it.
 
 Effectively participating in open source, whether simply consuming it effectively and strategically, or driving a particular standard costs money, primarily in the staffing area. You don’t need to start with a giant staff (more on that later), but you should be considering the needs you’ll have both in terms of software engineers and support staff (legal, business, project management) as you begin to put policies into place to help govern your organization’s open source efforts.
 


### PR DESCRIPTION
It seems that "module" is used instead of "course" in this OSPO 101 guide. But this is just semantics.