### PR TITLE
Update Module 3 README

### DIFF
--- a/module3/README.md
+++ b/module3/README.md
@@ -330,7 +330,7 @@ Microsoft is now an accepted big player in the open source space, but just a few
 
 That’s when the exploration of what Microsoft could do with open source began in earnest, McAffer said. In the early days, if anyone in the company was interested in doing anything with open source, they came to the centralized group for assistance from the open source developers, contributors, and maintainers involved.
 
-About three years ago, things began to change. Microsoft decided to make open source pervasive throughout the company and rolled open source into the main engineering groups.
+Around the year 2014, things began to change. Microsoft decided to make open source pervasive throughout the company and rolled open source into the main engineering groups.
 
 > "If that’s all we had done, we would have left an untenable vacuum around how we do open source," said McAffer. “Someone has to think about policy and how all the open source efforts would be coordinated, the processes and tools they would use, how would we keep track of projects, etc. So, we created what is now known as the Open Source Programs Office to handle all those issues.”
 

--- a/module3/README.md
+++ b/module3/README.md
@@ -282,7 +282,7 @@ Comcast’s involvement in open source was a gradual process that evolved over t
 
 Comcast began contributing to open source around 2006 when Jon Moore, Chief Software Architect, made a patch contribution to Apache HTTP. He showed the management team that it was more cost effective to have the patch incorporated into the main project than it was to maintain it separately.
 
-Working with an interdisciplinary team, Moore worked to set up an open source advisory council, which consisted of legal and technical subject matter experts. They reviewed contributions and created internal guidelines focused on good open source practices and community building. In 2013, when they started tracking these contributions, they had 13. They had plans to 10x that in 2017.
+Working with an interdisciplinary team, Moore worked to set up an open source advisory council, which consisted of legal and technical subject matter experts. They reviewed contributions and created internal guidelines focused on good open source practices and community building. In 2013, when they started tracking these contributions, they had 13. They had plans to do almost 10x more of that in 2017.
 
 *"When companies establish open source practices they send a big message saying that we’re serious about open source and that we want to invest in it."* – Nithya Ruff, Senior Director Open Source Practice at Comcast.
 

--- a/module3/README.md
+++ b/module3/README.md
@@ -282,7 +282,7 @@ Comcast’s involvement in open source was a gradual process that evolved over t
 
 Comcast began contributing to open source around 2006 when Jon Moore, Chief Software Architect, made a patch contribution to Apache HTTP. He showed the management team that it was more cost effective to have the patch incorporated into the main project than it was to maintain it separately.
 
-Working with an interdisciplinary team, Moore worked to set up an open source advisory council, which consisted of legal and technical subject matter experts. They reviewed contributions and created internal guidelines focused on good open source practices and community building. In 2013, when they started tracking these contributions, they had 13. This year, they plan to do almost 10x that.
+Working with an interdisciplinary team, Moore worked to set up an open source advisory council, which consisted of legal and technical subject matter experts. They reviewed contributions and created internal guidelines focused on good open source practices and community building. In 2013, when they started tracking these contributions, they had 13. They had plans to 10x that in 2017.
 
 *"When companies establish open source practices they send a big message saying that we’re serious about open source and that we want to invest in it."* – Nithya Ruff, Senior Director Open Source Practice at Comcast.
 


### PR DESCRIPTION
Issue #30 was raised by @winterrocks regarding the Comcast case study in Module 3 README.md, stating that: "...since the reader doesn't know when this was written it is impossible to know if the 10x is happening in 2014 or 2022 or some year between those years." 

So I made some research on Comcast's open-source program office to figure out when the documentation was likely penned down. I found this article(link below) was likely written on the Linux Foundation blog on September 29, 2017. So, this guided my change to the last line of that paragraph. With this update, there is clarity as to when the 10x increase possibly happened. 

[https://www.linuxfoundation.org/blog/comcast-open-source-program-success-depends-on-business-strategy-alignment/](url)